### PR TITLE
Remove unused dependency to fix bench build

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -9,12 +9,9 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.Digest.XXHash as XXHash
 import qualified Data.Digest.Adler32 as Adler32
 import qualified Data.Digest.CRC32 as CRC32
-import qualified Data.Digest.Murmur32 as M32
 import qualified Data.Hashable as Hashable
 
 import Criterion.Main
-import Control.DeepSeq
-instance NFData M32.Hash32
 
 main :: IO ()
 main = do

--- a/xxhash.cabal
+++ b/xxhash.cabal
@@ -49,7 +49,6 @@ benchmark bench
                        bytestring,
                        criterion,
                        digest,
-                       murmur-hash,
                        deepseq,
                        hashable,
                        xxhash


### PR DESCRIPTION
Fixes #4 

This would allow `xxhash` to be [unblocked in `stackage nightly`](https://github.com/fpco/stackage/blob/6746407a2615c38cd4bce07cce27132fa5b62291/build-constraints.yaml#L3500), as the package builds correctly with `ghc-8.4.1`. 